### PR TITLE
Fix panic in GetStreamLimitContent when video directory is empty

### DIFF
--- a/src/streamManager.go
+++ b/src/streamManager.go
@@ -354,12 +354,19 @@ func GetStreamLimitContent() ([]byte, bool) {
 			if err != nil {
 				ShowError(err, 0)
 			}
+			// The directory content has changed, read it again
+			fileList, err = os.ReadDir(System.Folder.Video)
+			if err != nil {
+				ShowError(err, 0)
+			}
 		}
-		content, err = os.ReadFile(System.Folder.Video + fileList[0].Name())
-		if err != nil {
-			ShowError(err, 0)
-		} else {
-			contentOk = true
+		if len(fileList) > 0 {
+			content, err = os.ReadFile(System.Folder.Video + fileList[0].Name())
+			if err != nil {
+				ShowError(err, 0)
+			} else {
+				contentOk = true
+			}
 		}
 	}
 	if !contentOk {


### PR DESCRIPTION
Title: Fix panic in GetStreamLimitContent when video directory is empty

## Reproduction

On a fresh install (empty `data/video/` and `data/images/custom/`):

1. Configure a playlist with a tuner limit (e.g. 1).
2. Open enough streams to reach the limit.
3. Request one more stream.

Every request that hits the tuner limit then dies with a per-request panic instead of serving the "no more streams" content:

```
runtime error: index out of range [0] with length 0
```

raised at `fileList[0].Name()` in `GetStreamLimitContent` (`src/streamManager.go`).

## Root cause

`os.ReadDir` on the video folder succeeds with an empty slice when the directory exists but contains no files, and the code reads `fileList[0]` unconditionally. In addition, when `CreateAlternativNoMoreStreamsVideo` does create a video (a custom image was uploaded), `fileList` is stale — it was read before the file existed — so the same index panic is hit even on that path.

## Fix

- Re-read the video directory after `CreateAlternativNoMoreStreamsVideo` so the freshly created file is picked up.
- Only read `fileList[0]` when the directory actually contains a file; otherwise `contentOk` stays false and the function falls through to the existing embedded `stream-limit.ts` fallback, which is exactly the intended default behavior.

With the fix, a fresh install at the tuner limit serves the embedded stream-limit content instead of panicking, and uploaded custom images are picked up correctly on the request that generated the video. Verified with `go build ./...`.
