### PR TITLE
Honor PUID/PGID environment variables at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$THREADFIN
 WORKDIR ${THREADFIN_HOME}
 
 # Install needed dependencies and configure environment
-RUN apk update && apk upgrade && apk add ca-certificates curl vlc doas tzdata jellyfin-ffmpeg\
+RUN apk update && apk upgrade && apk add ca-certificates curl vlc doas su-exec tzdata jellyfin-ffmpeg\
   && ln -s /usr/lib/jellyfin-ffmpeg/ffmpeg /usr/bin/ffmpeg \
   && apk cache clean \
   && apk info --installed | grep -v "required by" | xargs apk del --purge \
@@ -76,15 +76,16 @@ RUN apk update && apk upgrade && apk add ca-certificates curl vlc doas tzdata je
   && chown -R threadfin:threadfin ${THREADFIN_BIN} ${THREADFIN_CONF} ${THREADFIN_TEMP} ${THREADFIN_CACHE} \
   && chmod -R 755 ${THREADFIN_HOME}
 
-# Set user
-USER threadfin
-
 # Copy built binary from builder image
 COPY --from=builder /src/threadfin ${THREADFIN_BIN}/
+
+# Copy entrypoint script that honors PUID/PGID and drops privileges
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 # Configure container volume mappings
 VOLUME ${THREADFIN_CONF} ${THREADFIN_TEMP}
 
 EXPOSE ${THREADFIN_PORT}
 
-ENTRYPOINT ["/bin/sh", "-c", "threadfin -port=${THREADFIN_PORT} -config=${THREADFIN_CONF} -debug=${THREADFIN_DEBUG}"]
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+set -e
+
+# Started without root privileges (e.g. docker run --user): keep the current user
+if [ "$(id -u)" != "0" ]; then
+    exec threadfin -port="${THREADFIN_PORT}" -config="${THREADFIN_CONF}" -debug="${THREADFIN_DEBUG}"
+fi
+
+# Remap the threadfin user to the requested PUID/PGID (linuxserver.io convention).
+# Without PUID/PGID the container behaves exactly as before.
+if [ -n "${PUID}" ] || [ -n "${PGID}" ]; then
+    CURRENT_UID="$(id -u "${THREADFIN_USER}")"
+    CURRENT_GID="$(id -g "${THREADFIN_USER}")"
+    PUID="${PUID:-${CURRENT_UID}}"
+    PGID="${PGID:-${CURRENT_GID}}"
+
+    if [ "${PGID}" != "${CURRENT_GID}" ]; then
+        sed -i "s/^\(${THREADFIN_USER}:x\):${CURRENT_GID}:/\1:${PGID}:/" /etc/group
+    fi
+    if [ "${PUID}" != "${CURRENT_UID}" ] || [ "${PGID}" != "${CURRENT_GID}" ]; then
+        sed -i "s/^\(${THREADFIN_USER}:x\):${CURRENT_UID}:${CURRENT_GID}:/\1:${PUID}:${PGID}:/" /etc/passwd
+    fi
+
+    # Make sure the working directories are owned by the requested IDs
+    for dir in "${THREADFIN_BIN}" "${THREADFIN_CONF}" "${THREADFIN_TEMP}" "${THREADFIN_CACHE}"; do
+        if [ -d "${dir}" ] && [ "$(stat -c '%u:%g' "${dir}")" != "${PUID}:${PGID}" ]; then
+            chown -R "${PUID}:${PGID}" "${dir}"
+        fi
+    done
+fi
+
+# Drop root privileges and start Threadfin
+exec su-exec "${THREADFIN_USER}" threadfin -port="${THREADFIN_PORT}" -config="${THREADFIN_CONF}" -debug="${THREADFIN_DEBUG}"


### PR DESCRIPTION
Title: Honor PUID/PGID environment variables at runtime

## Problem

The image bakes `THREADFIN_UID=1000` / `THREADFIN_GID=1000` at build time and starts directly as that user. Runtime `PUID`/`PGID` environment variables are silently ignored. When the conf directory is bind-mounted and owned by any other UID (very common on NAS-style hosts where media users are e.g. 99:100), the container crash-loops with:

```
mkdir /home/threadfin/conf/...: permission denied
```

PUID/PGID is the de-facto convention for Docker home-server images (linuxserver.io standard, used across Unraid, Synology, QNAP and plain docker-compose setups), and it is what users migrating from other Threadfin images already expect — currently such migrations crash-loop on conf-dir permissions.

## Change

- Replace the inline `ENTRYPOINT` + static `USER threadfin` with a small `docker-entrypoint.sh`.
- The container now starts as root. If `PUID`/`PGID` are set, the entrypoint remaps the `threadfin` user to those IDs, chowns the working directories (`bin`, `conf`, `temp`, `cache`) only if their ownership does not already match, and then drops privileges with `su-exec` (added to the existing `apk add` line, ~20 kB).
- If `PUID`/`PGID` are **not** set, the process still runs as `threadfin` (1000:1000) with the same command line as before — no behavior change for existing users.
- If the container is started with `--user`, the entrypoint execs the binary directly as that user, same as today.

## Verification

Built the image and ran it both ways on a test system:

- `-e PUID=99 -e PGID=100` with a bind-mounted conf directory owned by `99:100`: container starts cleanly, the `threadfin` process runs as uid 99/gid 100 (`/etc/passwd` entry remapped to `threadfin:x:99:100`), and all files it creates in conf are owned `99:100`.
- No `PUID`/`PGID` set: container starts cleanly and the process runs as `threadfin` uid 1000/gid 1000, identical to the current image.
