### PR TITLE
Add Intel VAAPI driver so hardware transcoding works out of the box

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$THREADFIN
 WORKDIR ${THREADFIN_HOME}
 
 # Install needed dependencies and configure environment
-RUN apk update && apk upgrade && apk add ca-certificates curl vlc doas tzdata jellyfin-ffmpeg\
+RUN apk update && apk upgrade && apk add ca-certificates curl vlc doas tzdata jellyfin-ffmpeg intel-media-driver\
   && ln -s /usr/lib/jellyfin-ffmpeg/ffmpeg /usr/bin/ffmpeg \
   && apk cache clean \
   && apk info --installed | grep -v "required by" | xargs apk del --purge \


### PR DESCRIPTION
Title: Add Intel VAAPI driver so hardware transcoding works out of the box

## Symptom

Configuring a buffer/transcode profile that uses `h264_vaapi` fails immediately, and the buffer retries in a tight loop. ffmpeg reports:

```
Failed to initialise VAAPI connection: -1
```

even when `/dev/dri` is passed into the container and works fine with other images on the same host.

## Root cause

The image installs `jellyfin-ffmpeg` (which is built with VAAPI support) and `libva`, but no VAAPI **userspace driver**. `/usr/lib/dri/` is empty, so libva has no backend to load and every VAAPI init fails regardless of host GPU or device permissions.

## Fix

One package: add `intel-media-driver` to the existing `apk add` line. Alpine 3.21 ships it (24.4.3-r0); it installs `/usr/lib/dri/iHD_drv_video.so` and pulls in `intel-gmmlib` as its only extra dependency. This covers Intel GPUs (Broadwell and newer), which is the typical hardware for this kind of deployment.

## Verification

On a test system with an Intel iGPU, using the image built from this branch:

```
docker run --rm --device /dev/dri <image> /usr/lib/jellyfin-ffmpeg/ffmpeg \
  -v error -init_hw_device vaapi=va:/dev/dri/renderD128 \
  -f lavfi -i testsrc2=duration=2:size=1280x720:rate=25 \
  -vf format=nv12,hwupload -c:v h264_vaapi -f null -
```

exits with rc=0 and no errors. In an image built from the current Dockerfile, `/usr/lib/dri/` is empty (verified by inspecting the image), so libva has no driver to load and the VAAPI connection error above is unavoidable.
